### PR TITLE
tx delay for production clusterboard

### DIFF
--- a/arch/arm/dts/sun50i-a64-pine64-plus-u-boot.dtsi
+++ b/arch/arm/dts/sun50i-a64-pine64-plus-u-boot.dtsi
@@ -20,7 +20,8 @@
 			phy-mode = "rgmii";
 			phy = <&phy1>;
 			status = "okay";
-
+                        allwinner,tx-delay-ps = <200>;
+			
 			phy1: ethernet-phy@1 {
 				reg = <1>;
 			};


### PR DESCRIPTION
The SPI see's network, but needs a tx delay of at least 200 pico seconds for the network adapter to work. I have tested this in arch mainline but not the SPI build